### PR TITLE
Fix for memory leaks, and GCC 9 support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,6 @@ CC = gcc
 ARCH := $(shell uname -m)
 
 # Sanitizer
-SANITIZE.x86_64 += -mmpx
 SANITIZE.aarch64 :=
 
 SANITIZE += $(SANITIZE.$(ARCH))
@@ -45,6 +44,7 @@ CFLAGS += -Wall
 CFLAGS += -Wextra
 CFLAGS += -Werror
 CFLAGS += -pedantic -Wpedantic
+CLFAGS += -Wno-cast-function-type -Wno-error=cast-function-type
 
 CFLAGS += -fno-common
 CFLAGS += -fstrict-aliasing

--- a/src/dmn/trn_transitd.h
+++ b/src/dmn/trn_transitd.h
@@ -47,7 +47,7 @@
 				"inserting [%s] for first time. allocate memory for interface key," \
 				" since RPC XDR will eventually free its value.",                   \
 				itf);                                                               \
-			e.key = malloc(sizeof(char) * strlen(itf));                                 \
+			e.key = malloc(sizeof(char) * strlen(itf) + 1);                             \
 			strcpy(e.key, itf);                                                         \
 			ep = hsearch(e, ENTER);                                                     \
 		}                                                                                   \

--- a/src/include/trn_datamodel.h
+++ b/src/include/trn_datamodel.h
@@ -67,7 +67,7 @@ struct endpoint_t {
 	__u32 remote_ips[TRAN_MAX_REMOTES];
 	int hosted_iface;
 	unsigned char mac[6];
-} __attribute__((packed));
+} __attribute__((packed, aligned(4)));
 
 struct network_key_t {
 	__u32 prefixlen; /* up to 32 for AF_INET, 128 for AF_INET6*/
@@ -79,7 +79,7 @@ struct network_t {
 	__u32 nip[3];
 	__u32 nswitches;
 	__u32 switches_ips[TRAN_MAX_NSWITCH];
-} __attribute__((packed));
+} __attribute__((packed, aligned(4)));
 
 struct vpc_key_t {
 	union {
@@ -90,7 +90,7 @@ struct vpc_key_t {
 struct vpc_t {
 	__u32 nrouters;
 	__u32 routers_ips[TRAN_MAX_NROUTER];
-} __attribute__((packed));
+} __attribute__((packed, aligned(4)));
 
 struct tunnel_iface_t {
 	int iface_index;
@@ -104,7 +104,7 @@ struct agent_metadata_t {
 	struct network_t net;
 	struct endpoint_key_t epkey;
 	struct endpoint_t ep;
-} __attribute__((packed));
+} __attribute__((packed, aligned(4)));
 
 struct ipv4_tuple_t {
 	__u32 saddr;


### PR DESCRIPTION
### **Makefile**
- **Removed mmpx compilation flag.**
[Intel MPX has been deprecated by Intel, and is no longer supported by GCC and Linux.](https://intel-mpx.github.io)

- **Added compilation flags -Wno-cast-function-type and -Wno-error=cast-function-type.**
GCC 8+ added the  -Wcast-function-type warning. This flag warns when a function pointer is cast to an incompatible function. This causes issues for our RPC generated code in the later versions of GCC. Adding a compiler directive with #pragma fixes this issue for GCC 8+. However this causes issues with older versions of GCC, since it doesn't exist..

### **src/include/trn_datamodel.h** 
- **Aligned all structs used in the agent_metadata struct.**
This fixes compiler warnings in GCC 9, and possible future issues like the one we saw in the unit tests.

### **src/cli/trn_cli.c**
- **Allocate an extra byte for the end of string character '\0'** 
Fixes buffer overflow.

- **Free allocated memory in CLI**
Fixes memory leak.

### **src/dmn/trn_transitd.h**
- **Allocate an extra byte for the end of string character '\0'** 
Fixes buffer overflow.